### PR TITLE
Scythe rusviet edit

### DIFF
--- a/scythe/en/playeraid.yaml
+++ b/scythe/en/playeraid.yaml
@@ -450,8 +450,8 @@ sections:
           - name: Rusviet
             text: |
                 * **Relentless** (faction ability): You may choose the same
-                  section on your player mat multiple turns in a row. This
-                  also applies to a factory card you may have.
+                  section on your player mat multiple turns in a row. **This
+                  can not be used to visit a factory card multiple turns in a row.**
                 * **Riverwalk**: Your character and mechs can move across
                   rivers onto farms and villages.
                 * **Township**: For move actions for your character/mechs,

--- a/scythe/en/playeraid.yaml
+++ b/scythe/en/playeraid.yaml
@@ -451,7 +451,7 @@ sections:
             text: |
                 * **Relentless** (faction ability): You may choose the same
                   section on your player mat multiple turns in a row. **This
-                  can not be used to visit a factory card multiple turns in a row.**
+                  cannot be used to visit a factory card multiple turns in a row.**
                 * **Riverwalk**: Your character and mechs can move across
                   rivers onto farms and villages.
                 * **Township**: For move actions for your character/mechs,

--- a/scythe/en/playeraid.yaml
+++ b/scythe/en/playeraid.yaml
@@ -451,7 +451,7 @@ sections:
             text: |
                 * **Relentless** (faction ability): You may choose the same
                   section on your player mat multiple turns in a row. **This
-                  cannot be used to visit a factory card multiple turns in a row.**
+                  cannot be used to choose a factory card multiple turns in a row.**
                 * **Riverwalk**: Your character and mechs can move across
                   rivers onto farms and villages.
                 * **Township**: For move actions for your character/mechs,


### PR DESCRIPTION
Hello, per the current Scythe FAQ (https://stonemaiergames.com/games/scythe/faq-scythe/) the Rusviet faction cannot use the Relentless ability to choose a Factory card multiple turns in a row, I have updated the Scythe player aid to reflect that. Please let me know if you have any questions!